### PR TITLE
add support for sqlpackage version 16.x

### DIFF
--- a/PublishDacPac/public/Find-SqlPackageLocations.ps1
+++ b/PublishDacPac/public/Find-SqlPackageLocations.ps1
@@ -37,6 +37,7 @@ function Find-SqlPackageLocations {
         $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles(x86)}\Microsoft SQL Server\*\DAC\bin" -ErrorAction SilentlyContinue;
         $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio *\Common7\IDE\Extensions\Microsoft\SQLDB\DAC" -ErrorAction SilentlyContinue;
         $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\*\*\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\" -ErrorAction SilentlyContinue;    
+        $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles}\Microsoft Visual Studio\*\*\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\" -ErrorAction SilentlyContinue;    
 
         # For those that install SQLPackage.exe in a completely different location, set environment variable CustomSqlPackageInstallLocation
         $CustomInstallLocation = [Environment]::GetEnvironmentVariable('CustomSqlPackageInstallLocation');

--- a/PublishDacPac/public/Get-SqlPackagePath.ps1
+++ b/PublishDacPac/public/Get-SqlPackagePath.ps1
@@ -22,8 +22,9 @@ function Get-SqlPackagePath {
 
     .PARAMETER Version
     Defines the specific version of SqlPackage.exe to which you wish to obtain the path.
-    Valid values for -Version are: ('15', '14', '13', '12', '11') which translate as follows:
+    Valid values for -Version are: ('16', '15', '14', '13', '12', '11') which translate as follows:
 
+    * 16: SQL Server 2022
     * 15: SQL Server 2019
     * 14: SQL Server 2017
     * 13: SQL Server 2016
@@ -56,7 +57,7 @@ function Get-SqlPackagePath {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet('150', '140', '130', '120', '110', '15', '14', '13', '12', '11')]
+        [ValidateSet('150', '140', '130', '120', '110', '16', '15', '14', '13', '12', '11')]
         [string]$Version
     )
 
@@ -69,6 +70,7 @@ function Get-SqlPackagePath {
     $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles(x86)}\Microsoft SQL Server\*\DAC\bin" -ErrorAction SilentlyContinue;
     $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio *\Common7\IDE\Extensions\Microsoft\SQLDB\DAC" -ErrorAction SilentlyContinue;
     $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\*\*\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\" -ErrorAction SilentlyContinue;    
+    $PathsToSearch += Resolve-Path -Path "${env:ProgramFiles}\Microsoft Visual Studio\*\*\Common7\IDE\Extensions\Microsoft\SQLDB\DAC\" -ErrorAction SilentlyContinue;    
 
     # For those that install SQLPackage.exe in a completely different location, set environment variable CustomSqlPackageInstallLocation
     $CustomInstallLocation = [Environment]::GetEnvironmentVariable('CustomSqlPackageInstallLocation');

--- a/PublishDacPac/public/Publish-DacPac.ps1
+++ b/PublishDacPac/public/Publish-DacPac.ps1
@@ -50,6 +50,7 @@
     Recommed you use the latest version of SqlPackage.exe as this will deploy to all previous version of SQL Server.
 
         latest = use the latest version of SqlPackage.exe
+        16 = SQL Server 2022
         15 = SQL Server 2019
         14 = SQL Server 2017
         13 = SQL Server 2016
@@ -136,7 +137,7 @@
         $SqlCmdVariables,
 
         [String] [Parameter(Mandatory = $false)]
-        [ValidateSet('150', '140', '130', '120', '110', '15', '14', '13', '12', '11', 'latest')]
+        [ValidateSet('150', '140', '130', '120', '110', '16', '15', '14', '13', '12', '11', 'latest')]
         $PreferredVersion = 'latest',
 
         [String] [Parameter(Mandatory = $false)]        

--- a/PublishDacPac/public/Select-SqlPackageVersion.ps1
+++ b/PublishDacPac/public/Select-SqlPackageVersion.ps1
@@ -13,6 +13,7 @@ function Select-SqlPackageVersion {
     Valid values for -Version are: ('15', '14', '13', '12', '11') which translate as follows:
 
         latest = use the latest version of SqlPackage.exe
+        16 = SQL Server 2022
         15 = SQL Server 2019
         14 = SQL Server 2017
         13 = SQL Server 2016
@@ -45,13 +46,13 @@ function Select-SqlPackageVersion {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet('150', '140', '130', '120', '110', '15', '14', '13', '12', '11', 'latest')]
+        [ValidateSet('150', '140', '130', '120', '110', '16', '15', '14', '13', '12', '11', 'latest')]
         [string] $PreferredVersion
     )
 
     try {
         $specificVersion = $PreferredVersion -and $PreferredVersion -ne 'latest';
-        $versions = '15', '14', '13', '12', '11' | Where-Object { $_ -ne $PreferredVersion }
+        $versions = '16', '15', '14', '13', '12', '11' | Where-Object { $_ -ne $PreferredVersion }
 
         # Look for a specific version of Microsoft SQL Server SqlPackage.exe
         if ($specificVersion) {


### PR DESCRIPTION
sqlpackage as installed with visual studio 2022 enterprise is version 16.x and is needed to publish against my local sql2022 instance.
